### PR TITLE
create and use a root XML file instead of archive-syncfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-slim
 LABEL maintainer="OpenStax Content Engineering"
 
 RUN apt update
-RUN apt install -y build-essential wget git
+RUN apt install -y build-essential wget git xmlstarlet
 
 ENV JQ_VERSION='1.6'
 ENV CODE_DIR=/code/scripts

--- a/pipeline-sync.yml
+++ b/pipeline-sync.yml
@@ -57,7 +57,7 @@ jobs:
 
               cd $OSBOOK
               bash $CODE_DIR/sync.sh
-              git config --global user.email "openstax@openstax.com"
+              git config --global user.email "openstax@openstax.org"
               git config --global user.name "Content Synchronizer"
               git add .
               git commit -m "sync with archive $SERVER"

--- a/sync.sh
+++ b/sync.sh
@@ -1,12 +1,44 @@
 #!/usr/bin/env bash
 set -xeo pipefail
+
+# Upgrade from ./archive-syncfile to META-INF/books.xml
+if [[ ! -f ./META-INF/books.xml ]]
+then
+  [[ -d ./META-INF/ ]] || mkdir ./META-INF/
+
+  echo '<container xmlns="https://openstax.org/namespaces/book-container" version="1">' > ./META-INF/books.xml
+
+  while read slug collid
+  do
+    echo "    <book slug=\"${slug}\" collection-id=\"${collid}\" href=\"../collections/$slug.collection.xml\" />" >> ./META-INF/books.xml
+  done < ./archive-syncfile
+
+  echo '</container>' >> ./META-INF/books.xml
+fi
+
+# Create a temporary ./archive-syncfile
+xmlstarlet sel -t --match '//*[@slug]' --value-of '@slug' --value-of '" "' --value-of '@collection-id' --nl < ./META-INF/books.xml > ./archive-syncfile
+
+# Write the ./canonical.json file out
+[[ ! -f ./canonical-temp.txt ]] || rm ./canonical-temp.txt
+echo '[' > ./canonical.json
+while read slug collid
+do
+  echo "    \"${slug}\"" >> ./canonical-temp.txt
+done < ./archive-syncfile
+# Add a comma to every line except the last line https://stackoverflow.com/a/35021663
+sed '$!s/$/,/' ./canonical-temp.txt >> ./canonical.json
+rm ./canonical-temp.txt
+echo ']' >> ./canonical.json
+
+# Fetch the books and keep a list of module-ids
 while read slug collid
 do
   rm -rf ./"$slug"
   neb get -r -d $slug $SERVER $collid latest
   echo "--- $slug" >> module-ids
   find "./$slug/" -maxdepth 1 -mindepth 1 -type d | xargs -I{} basename {}  >> module-ids
-done < archive-syncfile
+done < ./archive-syncfile
 
 python $CODE_DIR/find-module-canonical.py > canonical-modules
 rm -rf modules collections metadata media
@@ -25,5 +57,5 @@ do
 done < archive-syncfile
 python $CODE_DIR/update_metadata.py modules collections metadata
 find modules/. -name metadata.json | xargs rm
-rm -rf metadata module-ids canonical-modules
+rm -rf ./metadata module-ids ./canonical-modules ./archive-syncfile
 echo 'Done.'


### PR DESCRIPTION
Instead of relying on an `/archive-syncfile` this relies on `META-INF/books.xml` as its source of truth.

If the `META-INF/books.xml` file does not exist the sync.sh script creates it; maybe this is overkill? We only have a few bundles so I can go through each and add the file.

The sync script also generates the `canonical.json` file until the downstream pipeline stops relying on it.

Example `META-INF/books.xml`:

```xml
<container xmlns="https://openstax.org/namespaces/book-container" version="1">
    <book slug="college-algebra" collection-id="col11759" href="../collections/college-algebra.collection.xml" />
    <book slug="precalculus"     collection-id="col11667" href="../collections/precalculus.collection.xml" />
</container>
```