### PR TITLE
update nebuchadnezzar to 9.9.1

### DIFF
--- a/resource-synchronizer/requirements.txt
+++ b/resource-synchronizer/requirements.txt
@@ -1,1 +1,1 @@
-nebuchadnezzar==9.8.16
+nebuchadnezzar==9.9.1


### PR DESCRIPTION
This fixes the intermittent download problems by adding exponential backoff to `neb get`