### PR TITLE
:bug: pipemgr utility: Use semver_constraint instead of tag for image versions

### DIFF
--- a/pipemgr/pyproject.toml
+++ b/pipemgr/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipemgr"
-version = "0.1.2"
+version = "0.1.3"
 description = "Helps manage the book syncing pipeline"
 authors = ["Tyler Nullmeier <tylerzeromaster@gmail.com>", "m1yag1 <mike.arbelaez@rice.edu>"]
 packages = [

--- a/pipemgr/src/templates/job.yml
+++ b/pipemgr/src/templates/job.yml
@@ -14,7 +14,7 @@ plan:
           username: ((ce-dockerhub-id))
           password: ((ce-dockerhub-token))
           repository: openstax/content-synchronizer
-          tag: 20211027.213953
+          semver_constraint: ">= 20211213.17322"
       inputs:
         - name: {{book-repo}}
       outputs:

--- a/pipemgr/src/templates/pipeline.yml
+++ b/pipemgr/src/templates/pipeline.yml
@@ -6,6 +6,6 @@ resource_types:
       username: ((ce-dockerhub-id))
       password: ((ce-dockerhub-token))
       repository: openstax/sync-resource
-      tag: 20211027.213953
+      semver_constraint: ">= 20211213.17322"
 resources: []
 jobs: []


### PR DESCRIPTION
Updated the templates to use semver_constraint instead of tag when selecting image versions to use in the sync-osbooks concourse pipeline. This will help make sure that the pipeline always uses the newest version of the images.